### PR TITLE
feat: Inception (Mercury 2) provider + API params & temperature UI adjustment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ cat ~/.config/DankMaterialShell/plugin_settings.json | jq .aiAssistant
 - OpenAI (gpt-5.2 models)
 - Anthropic (claude-4.5 models)
 - Google Gemini (gemini-2.5-flash, gemini-3-flash-preview)
-- Inception (OpenAI-compatible; [Inception Platform](https://platform.inceptionlabs.ai/))
+- Inception / Mercury 2: OpenAI-compatible chat completions plus [API parameters](https://docs.inceptionlabs.ai/get-started/api-parameters) (`reasoning_effort`, `reasoning_summary`, `reasoning_summary_wait`); [streaming](https://docs.inceptionlabs.ai/capabilities/streaming)
 - Custom (OpenAI-compatible endpoints)
 
 **Custom Provider Notes**:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@ cat ~/.config/DankMaterialShell/plugin_settings.json | jq .aiAssistant
 - OpenAI (gpt-5.2 models)
 - Anthropic (claude-4.5 models)
 - Google Gemini (gemini-2.5-flash, gemini-3-flash-preview)
+- Inception (OpenAI-compatible; [Inception Platform](https://platform.inceptionlabs.ai/))
 - Custom (OpenAI-compatible endpoints)
 
 **Custom Provider Notes**:

--- a/AIApiAdapters.js
+++ b/AIApiAdapters.js
@@ -53,6 +53,8 @@ function buildRequest(provider, payload, apiKey) {
         return anthropicRequest(payload, apiKey);
     case "gemini":
         return geminiRequest(payload, apiKey);
+    case "inception":
+        return inceptionRequest(payload, apiKey);
     case "custom":
         return customRequest(payload, apiKey);
     default:
@@ -70,6 +72,34 @@ function openaiRequest(payload, apiKey) {
         temperature: payload.temperature || 0.7,
         stream: true
     };
+    return { url, headers, body: JSON.stringify(body) };
+}
+
+function inceptionRequest(payload, apiKey) {
+    // Mercury 2 params: https://docs.inceptionlabs.ai/get-started/api-parameters
+    const url = openaiChatCompletionsUrl(payload.baseUrl || "https://api.inceptionlabs.ai/v1");
+    const headers = ["-H", "Content-Type: application/json", "-H", "Authorization: Bearer " + apiKey];
+    const maxTok = payload.max_tokens;
+    const mt = (typeof maxTok === "number" && maxTok > 0) ? Math.min(50000, maxTok) : 8192;
+    let t = (typeof payload.temperature === "number") ? payload.temperature : 0.75;
+    if (t < 0.5)
+        t = 0.5;
+    if (t > 1.0)
+        t = 1.0;
+    const body = {
+        model: payload.model,
+        messages: payload.messages,
+        max_tokens: mt,
+        temperature: t,
+        stream: true
+    };
+    const efforts = ["instant", "low", "medium", "high"];
+    const effort = String(payload.inceptionReasoningEffort || "medium").toLowerCase();
+    if (efforts.indexOf(effort) >= 0)
+        body.reasoning_effort = effort;
+    body.reasoning_summary = payload.inceptionReasoningSummary !== false;
+    if (payload.inceptionReasoningSummaryWait === true)
+        body.reasoning_summary_wait = true;
     return { url, headers, body: JSON.stringify(body) };
 }
 

--- a/AIAssistantService.qml
+++ b/AIAssistantService.qml
@@ -47,6 +47,9 @@ Item {
     property string sessionApiKey: "" // In-memory key
     property string apiKeyEnvVar: ""
     property bool useMonospace: false
+    property string inceptionReasoningEffort: "medium"
+    property bool inceptionReasoningSummary: true
+    property bool inceptionReasoningSummaryWait: false
 
     readonly property bool debugEnabled: (Quickshell.env("DMS_LOG_LEVEL") || "").toLowerCase() === "debug"
 
@@ -63,9 +66,12 @@ Item {
                 apiKey: "",
                 saveApiKey: false,
                 apiKeyEnvVar: "",
-                temperature: 0.7,
-                maxTokens: 4096,
-                timeout: 30
+                temperature: 0.75,
+                maxTokens: 8192,
+                timeout: 30,
+                inceptionReasoningEffort: "medium",
+                inceptionReasoningSummary: true,
+                inceptionReasoningSummaryWait: false
             };
         case "anthropic":
             return {
@@ -117,7 +123,7 @@ Item {
     function normalizedProfile(id, raw) {
         const defaults = defaultsForProvider(id);
         const p = raw || {};
-        return {
+        const profile = {
             baseUrl: String(p.baseUrl || defaults.baseUrl).trim(),
             model: String(p.model || defaults.model).trim(),
             apiKey: String(p.apiKey || "").trim(),
@@ -127,6 +133,14 @@ Item {
             maxTokens: (typeof p.maxTokens === "number") ? p.maxTokens : defaults.maxTokens,
             timeout: (typeof p.timeout === "number") ? p.timeout : defaults.timeout
         };
+        if (id === "inception") {
+            const efforts = ["instant", "low", "medium", "high"];
+            let eff = String(p.inceptionReasoningEffort || defaults.inceptionReasoningEffort || "medium").toLowerCase();
+            profile.inceptionReasoningEffort = efforts.indexOf(eff) >= 0 ? eff : "medium";
+            profile.inceptionReasoningSummary = (typeof p.inceptionReasoningSummary === "boolean") ? p.inceptionReasoningSummary : (defaults.inceptionReasoningSummary !== false);
+            profile.inceptionReasoningSummaryWait = !!p.inceptionReasoningSummaryWait;
+        }
+        return profile;
     }
 
     function mergedProviders(rawProviders) {
@@ -198,6 +212,11 @@ Item {
         apiKey = active.apiKey
         saveApiKey = active.saveApiKey
         apiKeyEnvVar = active.apiKeyEnvVar
+        if (provider === "inception") {
+            inceptionReasoningEffort = active.inceptionReasoningEffort || "medium";
+            inceptionReasoningSummary = active.inceptionReasoningSummary !== false;
+            inceptionReasoningSummaryWait = !!active.inceptionReasoningSummaryWait;
+        }
         useMonospace = PluginService.loadPluginData(pluginId, "useMonospace", false)
         suppressConfigChange = false
 
@@ -579,7 +598,7 @@ Item {
         }
 
         msgs.push({ role: "user", content: latestText });
-        return {
+        const payload = {
             provider: provider,
             baseUrl: baseUrl,
             model: model,
@@ -589,6 +608,12 @@ Item {
             stream: true,
             timeout: timeout
         };
+        if (provider === "inception") {
+            payload.inceptionReasoningEffort = inceptionReasoningEffort;
+            payload.inceptionReasoningSummary = inceptionReasoningSummary;
+            payload.inceptionReasoningSummaryWait = inceptionReasoningSummaryWait;
+        }
+        return payload;
     }
 
     function buildCurlCommand(payload) {

--- a/AIAssistantService.qml
+++ b/AIAssistantService.qml
@@ -56,6 +56,17 @@ Item {
 
     function defaultsForProvider(id) {
         switch (id) {
+        case "inception":
+            return {
+                baseUrl: "https://api.inceptionlabs.ai/v1",
+                model: "mercury-2",
+                apiKey: "",
+                saveApiKey: false,
+                apiKeyEnvVar: "",
+                temperature: 0.7,
+                maxTokens: 4096,
+                timeout: 30
+            };
         case "anthropic":
             return {
                 baseUrl: "https://api.anthropic.com",
@@ -123,13 +134,14 @@ Item {
             openai: normalizedProfile("openai", null),
             anthropic: normalizedProfile("anthropic", null),
             gemini: normalizedProfile("gemini", null),
+            inception: normalizedProfile("inception", null),
             custom: normalizedProfile("custom", null)
         };
 
         if (!rawProviders || typeof rawProviders !== "object")
             return base;
 
-        const ids = ["openai", "anthropic", "gemini", "custom"];
+        const ids = ["openai", "anthropic", "gemini", "inception", "custom"];
         for (let i = 0; i < ids.length; i++) {
             const id = ids[i];
             if (rawProviders[id] && typeof rawProviders[id] === "object") {
@@ -154,7 +166,7 @@ Item {
     function loadSettings() {
         suppressConfigChange = true
         const selectedProvider = String(PluginService.loadPluginData(pluginId, "provider", "openai")).trim() || "openai"
-        const providerId = ["openai", "anthropic", "gemini", "custom"].includes(selectedProvider) ? selectedProvider : "openai"
+        const providerId = ["openai", "anthropic", "gemini", "inception", "custom"].includes(selectedProvider) ? selectedProvider : "openai"
         const rawProviders = PluginService.loadPluginData(pluginId, "providers", null)
         let nextProviders = mergedProviders(rawProviders)
 
@@ -348,6 +360,8 @@ Item {
                 return Quickshell.env("DMS_ANTHROPIC_API_KEY") || "";
             case "gemini":
                 return Quickshell.env("DMS_GEMINI_API_KEY") || "";
+            case "inception":
+                return Quickshell.env("DMS_INCEPTION_API_KEY") || "";
             case "custom":
                 return Quickshell.env("DMS_CUSTOM_API_KEY") || "";
             default:
@@ -361,6 +375,8 @@ Item {
                 return Quickshell.env("ANTHROPIC_API_KEY") || "";
             case "gemini":
                 return Quickshell.env("GEMINI_API_KEY") || "";
+            case "inception":
+                return Quickshell.env("INCEPTION_API_KEY") || "";
             case "custom":
                 return "";
             default:

--- a/AIAssistantSettings.qml
+++ b/AIAssistantSettings.qml
@@ -28,6 +28,9 @@ Item {
     property real temperature: 0.7
     property int maxTokens: 4096
     property bool useMonospace: false
+    property string inceptionReasoningEffort: "medium"
+    property bool inceptionReasoningSummary: true
+    property bool inceptionReasoningSummaryWait: false
 
     function save(key, value) {
         PluginService.savePluginData(pluginId, key, value)
@@ -43,9 +46,12 @@ Item {
                 apiKey: "",
                 saveApiKey: false,
                 apiKeyEnvVar: "",
-                temperature: 0.7,
-                maxTokens: 4096,
-                timeout: 30
+                temperature: 0.75,
+                maxTokens: 8192,
+                timeout: 30,
+                inceptionReasoningEffort: "medium",
+                inceptionReasoningSummary: true,
+                inceptionReasoningSummaryWait: false
             };
         case "anthropic":
             return {
@@ -97,7 +103,7 @@ Item {
     function normalizedProfile(id, raw) {
         const d = defaultsForProvider(id)
         const p = raw || {}
-        return {
+        const profile = {
             baseUrl: String(p.baseUrl || d.baseUrl).trim(),
             model: String(p.model || d.model).trim(),
             apiKey: String(p.apiKey || "").trim(),
@@ -107,6 +113,14 @@ Item {
             maxTokens: (typeof p.maxTokens === "number") ? p.maxTokens : d.maxTokens,
             timeout: (typeof p.timeout === "number") ? p.timeout : d.timeout
         }
+        if (id === "inception") {
+            const efforts = ["instant", "low", "medium", "high"]
+            let eff = String(p.inceptionReasoningEffort || d.inceptionReasoningEffort || "medium").toLowerCase()
+            profile.inceptionReasoningEffort = efforts.indexOf(eff) >= 0 ? eff : "medium"
+            profile.inceptionReasoningSummary = (typeof p.inceptionReasoningSummary === "boolean") ? p.inceptionReasoningSummary : (d.inceptionReasoningSummary !== false)
+            profile.inceptionReasoningSummaryWait = !!p.inceptionReasoningSummaryWait
+        }
+        return profile
     }
 
     function mergedProviders(rawProviders) {
@@ -144,6 +158,11 @@ Item {
         apiKeyEnvVar = active.apiKeyEnvVar
         temperature = active.temperature
         maxTokens = active.maxTokens
+        if (provider === "inception") {
+            inceptionReasoningEffort = active.inceptionReasoningEffort || "medium"
+            inceptionReasoningSummary = active.inceptionReasoningSummary !== false
+            inceptionReasoningSummaryWait = !!active.inceptionReasoningSummaryWait
+        }
     }
 
     function setProvider(providerId) {
@@ -344,6 +363,82 @@ Item {
                                     placeholderText: "gpt-5.2"
                                     onEditingFinished: saveActiveField("model", text.trim())
                                 }
+
+                                StyledText {
+                                    width: parent.width
+                                    visible: root.provider === "inception"
+                                    text: I18n.tr("Mercury 2: temperature 0.5–1.0, max_tokens 1–50000 (see Inception API parameters).")
+                                    font.pixelSize: Theme.fontSizeSmall
+                                    color: Theme.surfaceVariantText
+                                    wrapMode: Text.WordWrap
+                                }
+
+                                StyledText {
+                                    text: I18n.tr("Reasoning effort")
+                                    font.pixelSize: Theme.fontSizeSmall
+                                    color: Theme.surfaceVariantText
+                                    visible: root.provider === "inception"
+                                }
+                                DankDropdown {
+                                    width: parent.width
+                                    visible: root.provider === "inception"
+                                    options: ["instant", "low", "medium", "high"]
+                                    currentValue: root.inceptionReasoningEffort
+                                    onValueChanged: value => saveActiveField("inceptionReasoningEffort", value)
+                                }
+
+                                RowLayout {
+                                    width: parent.width
+                                    spacing: Theme.spacingM
+                                    visible: root.provider === "inception"
+                                    Column {
+                                        Layout.fillWidth: true
+                                        spacing: Theme.spacingXS
+                                        StyledText {
+                                            text: I18n.tr("Reasoning summary")
+                                            font.pixelSize: Theme.fontSizeMedium
+                                            color: Theme.surfaceText
+                                        }
+                                        StyledText {
+                                            text: I18n.tr("Return a summary of the model's reasoning.")
+                                            font.pixelSize: Theme.fontSizeSmall
+                                            color: Theme.surfaceVariantText
+                                            wrapMode: Text.WordWrap
+                                            width: parent.width
+                                        }
+                                    }
+                                    DankToggle {
+                                        checked: root.inceptionReasoningSummary
+                                        onToggled: checked => saveActiveField("inceptionReasoningSummary", checked)
+                                    }
+                                }
+
+                                RowLayout {
+                                    width: parent.width
+                                    spacing: Theme.spacingM
+                                    visible: root.provider === "inception"
+                                    Column {
+                                        Layout.fillWidth: true
+                                        spacing: Theme.spacingXS
+                                        StyledText {
+                                            text: I18n.tr("Wait for reasoning summary")
+                                            font.pixelSize: Theme.fontSizeMedium
+                                            color: Theme.surfaceText
+                                        }
+                                        StyledText {
+                                            text: I18n.tr("Delay final response until the reasoning summary is ready.")
+                                            font.pixelSize: Theme.fontSizeSmall
+                                            color: Theme.surfaceVariantText
+                                            wrapMode: Text.WordWrap
+                                            width: parent.width
+                                        }
+                                    }
+                                    DankToggle {
+                                        checked: root.inceptionReasoningSummaryWait
+                                        onToggled: checked => saveActiveField("inceptionReasoningSummaryWait", checked)
+                                    }
+                                }
+
                             }
                         }
                     }
@@ -485,7 +580,7 @@ Item {
                                     width: parent.width - parent.spacing - Theme.iconSize
 
                                     StyledText {
-                                        text: I18n.tr("Temperature: %1").arg(root.temperature.toFixed(1))
+                                        text: I18n.tr("Temperature: %1").arg(root.temperature.toFixed(2))
                                         font.pixelSize: Theme.fontSizeLarge
                                         font.weight: Font.Medium
                                         color: Theme.surfaceText
@@ -505,10 +600,11 @@ Item {
                                 width: parent.width
                                 height: 32
                                 minimum: 0
-                                maximum: 20
-                                value: Math.round(root.temperature * 10)
+                                maximum: 200
+                                step: 1
+                                value: Math.round(root.temperature * 100)
                                 showValue: false
-                                onSliderValueChanged: newValue => saveActiveField("temperature", newValue / 10)
+                                onSliderValueChanged: newValue => saveActiveField("temperature", newValue / 100)
                             }
                         }
                     }

--- a/AIAssistantSettings.qml
+++ b/AIAssistantSettings.qml
@@ -36,6 +36,17 @@ Item {
 
     function defaultsForProvider(id) {
         switch (id) {
+        case "inception":
+            return {
+                baseUrl: "https://api.inceptionlabs.ai/v1",
+                model: "mercury-2",
+                apiKey: "",
+                saveApiKey: false,
+                apiKeyEnvVar: "",
+                temperature: 0.7,
+                maxTokens: 4096,
+                timeout: 30
+            };
         case "anthropic":
             return {
                 baseUrl: "https://api.anthropic.com",
@@ -103,12 +114,13 @@ Item {
             openai: normalizedProfile("openai", null),
             anthropic: normalizedProfile("anthropic", null),
             gemini: normalizedProfile("gemini", null),
+            inception: normalizedProfile("inception", null),
             custom: normalizedProfile("custom", null)
         }
         if (!rawProviders || typeof rawProviders !== "object")
             return next
 
-        const ids = ["openai", "anthropic", "gemini", "custom"]
+        const ids = ["openai", "anthropic", "gemini", "inception", "custom"]
         for (let i = 0; i < ids.length; i++) {
             const id = ids[i]
             if (rawProviders[id] && typeof rawProviders[id] === "object") {
@@ -164,7 +176,7 @@ Item {
 
     function load() {
         const selectedProvider = String(PluginService.loadPluginData(pluginId, "provider", "openai")).trim() || "openai"
-        provider = ["openai", "anthropic", "gemini", "custom"].includes(selectedProvider) ? selectedProvider : "openai"
+        provider = ["openai", "anthropic", "gemini", "inception", "custom"].includes(selectedProvider) ? selectedProvider : "openai"
 
         const rawProviders = PluginService.loadPluginData(pluginId, "providers", null)
         let nextProviders = mergedProviders(rawProviders)
@@ -302,7 +314,7 @@ Item {
                                 }
                                 DankDropdown {
                                     width: parent.width
-                                    options: ["openai", "anthropic", "gemini", "custom"]
+                                    options: ["openai", "anthropic", "gemini", "inception", "custom"]
                                     currentValue: root.provider
                                     onValueChanged: value => setProvider(value)
                                 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,21 +8,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Inception** provider for [Inception Platform](https://platform.inceptionlabs.ai/) (OpenAI-compatible streaming API; default base `https://api.inceptionlabs.ai/v1`, model `mercury-2`). API keys: `INCEPTION_API_KEY` / `DMS_INCEPTION_API_KEY`
+
+- **Inception** / Mercury 2: [API parameters](https://docs.inceptionlabs.ai/get-started/api-parameters) in settings (`reasoning_effort`, `reasoning_summary`, `reasoning_summary_wait`). Temperature clamped 0.5–1.0 per docs
 
 ## [1.4.0] - 2026-03-01
 
 ### Changed
+
 - Replaced custom markdown parser with [marked.js v1.2.9](https://github.com/markedjs/marked) (MIT License), inlined as a self-contained UMD bundle with a Qt Rich Text-compatible custom renderer
 - Proper handling of all standard GFM constructs: nested lists, loose list items, setext headings, link definitions, strikethrough, task lists, and more
 
 ### Fixed
+
 - Code blocks and blockquotes inside ordered list items no longer cause numbering to reset; code block tables are hoisted outside `<li>` elements using `<ol start="N">` segments to avoid Qt list-item indentation
 - Code block content indentation from being inside a list item is now correctly stripped by marked's built-in fence indentation compensation
 
 ## [1.3.3] - 2026-03-01
 
 ### Fixed
+
 - Ordered list numbering no longer resets to 1 when a code block, table, or blockquote appears between list items; uses `<ol start="N">` segments to preserve numbering
 - Blockquotes inside ordered list items now render correctly instead of appearing as literal `&gt;` text
 - Code blocks inside list items no longer display with the list's indentation; common leading whitespace is stripped before rendering
@@ -31,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.3.2] - 2026-02-28
 
 ### Fixed
+
 - Robust markdown placeholder system to prevent rendering issues with inline code and other elements
 - Inline code styling refined to use CSS padding instead of non-breaking spaces
 - Improved restoration logic for protected markdown blocks to ensure perfect HTML output
@@ -38,10 +43,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.3.1] - 2026-02-28
 
 ### Added
+
 - Copy button for code blocks to easily copy snippets to clipboard (fixes #5)
 - Visual feedback hint ("Copied to clipboard") when copying text or code
 
 ### Fixed
+
 - Code block layout issues including extra spacing, horizontal overflow, and background gaps
 - Settings panel sizing issues by providing implicit dimensions (fixes #3)
 - Bug where long code lines could break the message bubble structure
@@ -49,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.3.0] - 2026-02-28
 
 ### Added
+
 - Per-provider settings profiles via new `providers` persisted object, so switching providers loads each provider's own endpoint/model/token settings
 - New chat confirmation dialog when history exists
 - Privacy note based on the AI service provider (remote vs. local)
@@ -57,10 +65,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Redesigned composer with improved layout and icon buttons
 
 ### Changed
+
 - Provider switch in settings now immediately swaps to that provider's saved profile instead of reusing the previous provider's configuration
 - Composer layout optimized for better space usage and readability
 
 ### Fixed
+
 - Requests using stale custom endpoint/model settings after switching provider from the dropdown
 - Chat history being cleared when switching providers (history is now retained per provider configuration)
 - Gemini requests failing with HTTP 400 due to unsupported `stream` field in request body
@@ -69,37 +79,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.2.0] - 2026-02-24
 
 ### Added
+
 - Enter key now sends messages (Shift+Enter inserts newline) - issue #6
 - Regenerate button on assistant messages (appears on hover) - issue #6
 
 ### Changed
+
 - Send/Stop buttons are now icon-only (40x40) with tooltips - issue #6
 - Improved Gemini streaming finalization to handle `usageMetadata` end-of-stream signal
 
 ## [1.1.3] - 2026-02-21
 
 ### Fixed
+
 - Settings dropdown becoming non-interactive after toggling the plugin off/on from DMS settings while the settings panel was open
 
 ## [1.1.2] - 2026-02-18
 
 ### Fixed
+
 - Provider dropdown in the settings panel becoming non-interactive after closing and reopening the panel without restarting DMS
 
 ## [1.1.1] - 2026-02-12
 
 ### Fixed
+
 - Streaming responses appearing empty due to `curl --compressed` interfering with `StdioCollector` stdout capture
 
 ## [1.1.0] - 2026-01-17
 
 ### Added
+
 - Table rendering support in markdown with borders and proper cell alignment
 - Task list rendering with checkbox symbols (☑ for checked, ☐ for unchecked)
 - Strikethrough text support (`~~text~~` syntax)
 - Code block language labels (displays language identifier above code blocks)
 
 ### Fixed
+
 - Header spacing issues - now use CSS margins for consistent spacing
 - Code block background gaps with proper margin application
 - Settings panel sliders showing duplicate values on hover (e.g., "51205120" instead of "5120")
@@ -108,12 +125,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Code block language labels now use padding instead of margin to eliminate gaps
 
 ### Changed
+
 - Slider values now display in setting labels instead of tooltips for always-visible feedback
 - Updated markdown2html.js header comment to accurately describe supported features
 
 ## [1.0.0] - 2026-01-16
 
 ### Added
+
 - Initial release of AI Assistant plugin
 - Support for multiple AI providers (OpenAI, Anthropic, Gemini, Custom)
 - Streaming response support with real-time rendering
@@ -128,6 +147,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive settings panel with live updates
 
 ### Fixed
+
 - Settings persistence bug where configuration wouldn't load after restart
 - Race condition with pluginId initialization
 - Whitespace handling in text input fields

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the AI Assistant plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Inception** provider for [Inception Platform](https://platform.inceptionlabs.ai/) (OpenAI-compatible streaming API; default base `https://api.inceptionlabs.ai/v1`, model `mercury-2`). API keys: `INCEPTION_API_KEY` / `DMS_INCEPTION_API_KEY`
+
 ## [1.4.0] - 2026-03-01
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Provider: inception
 Base URL: https://api.inceptionlabs.ai/v1
 Model: mercury-2
 API Key: Your Inception API key
+Mercury 2 options (see [API parameters](https://docs.inceptionlabs.ai/get-started/api-parameters)): reasoning effort, reasoning summary, wait-for-reasoning-summary. Temperature is clamped to **0.5–1.0**; default max_tokens **8192** for new Inception profiles.
 ```
 
 #### Custom Provider

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ An integrated AI chat assistant plugin for DankMaterialShell with support for mu
 ## Features
 
 - **Multiple AI Provider Support**: OpenAI, Anthropic, Google Gemini, and custom OpenAI-compatible APIs
+- **Inception Platform Support**: Inception’s OpenAI-compatible streaming API
 - **Streaming Responses**: Real-time streaming of AI responses with proper cancellation support
 - **Markdown Rendering**: Full markdown support with syntax highlighting for code blocks
 - **Persistent Chat History**: Conversations are saved and restored across sessions
@@ -15,8 +16,8 @@ An integrated AI chat assistant plugin for DankMaterialShell with support for mu
 
 ## Screenshots
 
-| Chat Interface | Settings Panel |
-|----------------|----------------|
+| Chat Interface                                             | Settings Panel                                                 |
+| ---------------------------------------------------------- | -------------------------------------------------------------- |
 | ![Chat](screenshots/AI_ASSISTANT_SCREENSHOT_CURRENT_1.png) | ![Settings](screenshots/AI_ASSISTANT_SCREENSHOT_CURRENT_5.png) |
 
 ## Requirements
@@ -87,6 +88,15 @@ Model: gemini-2.5-flash (production) or gemini-3-flash-preview (experimental)
 API Key: Your Google API key
 ```
 
+#### Inception Platform (OpenAI-compatible)
+
+```
+Provider: inception
+Base URL: https://api.inceptionlabs.ai/v1
+Model: mercury-2
+API Key: Your Inception API key
+```
+
 #### Custom Provider
 
 For any OpenAI-compatible API (LocalAI, Ollama, LM Studio, etc.):
@@ -140,15 +150,15 @@ The AI Assistant can be triggered via:
 
 2. **Keybind**: Configure in your compositor configuration
 
-  ```kdl
-  # Niri example:
-  Mod+A { spawn "dms" "ipc" "call" "plugins" "toggle" "aiAssistant"; }
-  ```
+```kdl
+# Niri example:
+Mod+A { spawn "dms" "ipc" "call" "plugins" "toggle" "aiAssistant"; }
+```
 
-  ```conf
-  # Hyprland example:
-  bind = SUPER, A, exec, dms ipc call plugins toggle aiAssistant
-  ```
+```conf
+# Hyprland example:
+bind = SUPER, A, exec, dms ipc call plugins toggle aiAssistant
+```
 
 ### Chat Interface
 
@@ -270,7 +280,7 @@ MIT License - see [LICENSE](LICENSE) file for details
 
 ## Credits
 
-- **Author**: Jon Rogers - *devnullvoid*
+- **Author**: Jon Rogers - _devnullvoid_
 - **DankMaterialShell**: [DankMaterialShell Project](https://github.com/AvengeMedia/DankMaterialShell)
 - **QML/Qt**: [Qt Project](https://www.qt.io/)
 


### PR DESCRIPTION
Enjoying their diffusion based model a lot for quick questions, so I wanted to add native support. For testing they offer API access with 10m tokes just with sign-up. Have tested all options

AI Disclosure: Change was mostly done via Cursor

### PR Description 
Adds support for **[Inception Platform](https://platform.inceptionlabs.ai/)** / **Mercury 2** and aligns the settings UX with their [API parameters](https://docs.inceptionlabs.ai/get-started/api-parameters).

#### Provider: `inception`
- New provider preset: base `https://api.inceptionlabs.ai/v1`, default model `mercury-2`.
- Uses dedicated **`inceptionRequest`** in `AIApiAdapters.js` (OpenAI-style chat completions + Mercury 2 fields).
- API keys: saved/session/env; also **`INCEPTION_API_KEY`** / **`DMS_INCEPTION_API_KEY`**.

#### Mercury 2 request body (from docs)
- **`reasoning_effort`**: `instant` | `low` | `medium` | `high` (dropdown, default `medium`).
- **`reasoning_summary`**: toggle (default on).
- **`reasoning_summary_wait`**: toggle (default off).
- **`temperature`**: clamped **0.5–1.0** in the adapter; **`max_tokens`** clamped **1–50000** (default **8192** when unset for Inception).
- **`stream: true`** unchanged (keeps Stop/cancel behavior).

#### Intentionally not exposed
- **`diffusing`** — not useful with the current chat UI (no meaningful step-by-step display).
- **`stop`** / **`stream_options.include_usage`** — removed to keep settings simple.

#### Small change: temperature display
- Settings temperature slider used **0.1** steps; **0.75** rounded to **0.8**. Slider is now **0.01** steps (0–2.00) and label shows **two** decimals (e.g. `0.75`).
