### PR TITLE
Add support for newer openai models

### DIFF
--- a/AIApiAdapters.js
+++ b/AIApiAdapters.js
@@ -70,7 +70,6 @@ function openaiRequest(payload, apiKey, maxTokenParam = "max_completion_tokens")
     const body = {
         model: payload.model,
         messages: payload.messages,
-        temperature: payload.temperature || 0.7,
         stream: true
     };
     body[maxTokenParam] = payload.max_tokens || 1024;

--- a/AIApiAdapters.js
+++ b/AIApiAdapters.js
@@ -64,16 +64,16 @@ function buildRequest(provider, payload, apiKey) {
     }
 }
 
-function openaiRequest(payload, apiKey) {
+function openaiRequest(payload, apiKey, maxTokenParam = "max_completion_tokens") {
     const url = openaiChatCompletionsUrl(payload.baseUrl || "https://api.openai.com");
     const headers = ["-H", "Content-Type: application/json", "-H", "Authorization: Bearer " + apiKey];
     const body = {
         model: payload.model,
         messages: payload.messages,
-        max_tokens: payload.max_tokens || 1024,
         temperature: payload.temperature || 0.7,
         stream: true
     };
+    body[maxTokenParam] = payload.max_tokens || 1024;
     return { url, headers, body: JSON.stringify(body) };
 }
 
@@ -145,7 +145,7 @@ function geminiRequest(payload, apiKey) {
 
 function customRequest(payload, apiKey) {
     // v1 fallback: treat as OpenAI-compatible.
-    return openaiRequest(payload, apiKey);
+    return openaiRequest(payload, apiKey, "max_tokens");
 }
 
 function ollamaRequest(payload) {

--- a/AIAssistantSettings.qml
+++ b/AIAssistantSettings.qml
@@ -91,7 +91,7 @@ Item {
         case "custom":
             return {
                 baseUrl: "https://api.openai.com",
-                model: "gpt-5.2",
+                model: "chat-latest",
                 apiKey: "",
                 saveApiKey: false,
                 apiKeyEnvVar: "",
@@ -102,7 +102,7 @@ Item {
         default:
             return {
                 baseUrl: "https://api.openai.com",
-                model: "gpt-5.2",
+                model: "chat-latest",
                 apiKey: "",
                 saveApiKey: false,
                 apiKeyEnvVar: "",

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
   "id": "aiAssistant",
   "name": "AI Assistant",
   "description": "Integrated AI chat assistant with markdown support",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "author": "devnullvoid",
   "type": "daemon",
   "capabilities": [


### PR DESCRIPTION
Changes:
- `max_tokens` (deprecated) replaced with `max_completion_tokens` 
- `temperature` removed, not supported on new models
- Default model set to chat-latest.